### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,12 +658,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
+dependencies = [
+ "castaway",
+ "itoa 1.0.1",
+ "ryu",
+ "serde 1.0.137",
+]
+
+[[package]]
 name = "config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "compact_str",
+ "compact_str 0.4.0",
  "config 0.11.0",
  "dirs",
  "log",
@@ -980,7 +1001,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "compact_str",
+ "compact_str 0.1.1",
  "config 0.1.0",
  "log",
  "proc_macro",
@@ -1505,7 +1526,7 @@ dependencies = [
  "axum 0.2.8",
  "bincode",
  "cfg-if 1.0.0",
- "compact_str",
+ "compact_str 0.1.1",
  "config 0.1.0",
  "database",
  "futures",
@@ -1940,7 +1961,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "colored",
- "compact_str",
+ "compact_str 0.1.1",
  "config 0.1.0",
  "crossfire",
  "futures",
@@ -4245,7 +4266,7 @@ dependencies = [
  "byte-unit",
  "cfg-if 1.0.0",
  "chrono",
- "compact_str",
+ "compact_str 0.1.1",
  "crossfire",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,16 +649,6 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7fbe0058cad3f47c64669628b9f4ebbd4d5b3a186c0da99b915cd526fdcf6f"
-dependencies = [
- "serde 1.0.137",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
@@ -675,7 +665,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "compact_str 0.4.0",
+ "compact_str",
  "config 0.11.0",
  "dirs",
  "log",
@@ -1001,7 +991,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "compact_str 0.1.1",
+ "compact_str",
  "config 0.1.0",
  "log",
  "proc_macro",
@@ -1526,7 +1516,7 @@ dependencies = [
  "axum 0.2.8",
  "bincode",
  "cfg-if 1.0.0",
- "compact_str 0.1.1",
+ "compact_str",
  "config 0.1.0",
  "database",
  "futures",
@@ -1961,7 +1951,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "colored",
- "compact_str 0.1.1",
+ "compact_str",
  "config 0.1.0",
  "crossfire",
  "futures",
@@ -4266,7 +4256,7 @@ dependencies = [
  "byte-unit",
  "cfg-if 1.0.0",
  "chrono",
- "compact_str 0.1.1",
+ "compact_str",
  "crossfire",
  "log",
  "once_cell",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -15,7 +15,7 @@ config-rs = { version = "0.11", package = "config" }
 arc-swap = "1.3.0"
 once_cell = "1.7.2"
 notify = "5.0.0-pre.13"
-compact_str = { version = "0.1", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 parking_lot = "0.11"
 
 # models

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arc_swap::{ArcSwap, ArcSwapAny, Cache, Guard};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
@@ -55,7 +55,7 @@ pub fn hook(hook: Box<dyn Fn() + Send + Sync + 'static>) {
 ///
 /// 永远都应该在logger初始化之前初始化config.
 /// 因为logger依赖config, 如果在config初始化的时候打印log, 那么将会陷入死递归
-pub fn init(paths: Vec<CompactStr>) -> anyhow::Result<()> {
+pub fn init(paths: Vec<CompactString>) -> anyhow::Result<()> {
     CONFIG.set(Config::new(paths)?).ok();
     Ok(())
 }
@@ -68,7 +68,7 @@ struct Config {
 }
 
 impl Config {
-    fn new(paths: Vec<CompactStr>) -> anyhow::Result<Config> {
+    fn new(paths: Vec<CompactString>) -> anyhow::Result<Config> {
         let mut c = config_rs::Config::new();
         c.merge(
             config_rs::File::from_str(
@@ -127,7 +127,7 @@ impl Config {
         Ok(())
     }
 
-    fn watch(&self, paths: Vec<CompactStr>) -> notify::Result<()> {
+    fn watch(&self, paths: Vec<CompactString>) -> notify::Result<()> {
         let mut watcher = notify::recommended_watcher(
             |res: notify::Result<Event>| match res {
                 Ok(event) => {

--- a/config/src/models/http.rs
+++ b/config/src/models/http.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use utils::unit::time_unit::TimeUnit;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Copy, Clone)]
@@ -9,10 +9,10 @@ pub enum ListenType {
 }
 
 crate::gen_config!(HttpConfig, {
-    bind: CompactStr,
+    bind: CompactString,
     port: u16,
     r#type: ListenType,
     session_expiry: TimeUnit,
     overdue_check_interval: TimeUnit,
-    cors: Vec<CompactStr>
+    cors: Vec<CompactString>
 });

--- a/config/src/models/log.rs
+++ b/config/src/models/log.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use _log::Level;
 
 crate::gen_config!(LogConfig, {
-    filter: HashMap<CompactStr, Level>,
+    filter: HashMap<CompactString, Level>,
     level: Level
 });

--- a/config/src/models/site.rs
+++ b/config/src/models/site.rs
@@ -1,3 +1,3 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
-crate::gen_config!(SiteConfig, { name: CompactStr, title: CompactStr });
+crate::gen_config!(SiteConfig, { name: CompactString, title: CompactString });

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1"
 log = "0.4"
-compact_str = { version = "0.1", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 sqlx-core = { version = "0.5", default-features = false }
 
 [dependencies.sea-orm]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -22,7 +22,7 @@ headers = "0.3.4"
 async-session = "3.0.0"
 async-trait = "0.1.51"
 log = "0.4.14"
-compact_str = { version = "0.1", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 sea-orm = { version = "0.7", default-features = false, features = ["macros"] }
 bincode = "1.3"
 anyhow = "1.0"

--- a/http/src/cors.rs
+++ b/http/src/cors.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use axum::http::Request;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use hyper::header::{
     HeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, ORIGIN,
 };
@@ -13,7 +13,7 @@ use tower::Layer;
 
 #[derive(Clone, Debug)]
 pub struct CorsLayer {
-    origins: Vec<CompactStr>,
+    origins: Vec<CompactString>,
     allow_all: bool,
 }
 
@@ -31,8 +31,8 @@ pub struct ResponseFuture<F> {
 }
 
 impl CorsLayer {
-    pub fn new(origins: Vec<CompactStr>) -> Self {
-        if origins.contains(&CompactStr::new_inline("*")) {
+    pub fn new(origins: Vec<CompactString>) -> Self {
+        if origins.contains(&CompactString::new_inline("*")) {
             CorsLayer {
                 origins: Vec::new(),
                 allow_all: true,
@@ -85,7 +85,7 @@ where
                 .get(ORIGIN)
                 .map(|val| val.to_str().ok())
                 .flatten()
-                .map(CompactStr::new);
+                .map(CompactString::new);
             if let Some(origin) = origin {
                 if self.layer.origins.contains(&origin) {
                     allow_origin =

--- a/http/src/routes/auth.rs
+++ b/http/src/routes/auth.rs
@@ -9,7 +9,7 @@ use axum::http::Response;
 use axum::response::Html;
 use axum::routing::BoxRoute;
 use axum::{Json, Router};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use hyper::StatusCode;
 use anyhow::Context;
 
@@ -110,7 +110,7 @@ pub async fn login(
 
 #[derive(serde::Deserialize)]
 pub struct LoginData {
-    password: CompactStr,
+    password: CompactString,
 }
 
 pub async fn logout(

--- a/http/src/routes/edit.rs
+++ b/http/src/routes/edit.rs
@@ -8,7 +8,7 @@ use axum::http::StatusCode;
 use axum::response::Html;
 use axum::routing::BoxRoute;
 use axum::{extract, Json, Router};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use sea_orm::DatabaseConnection;
 
 use config::SiteConfig;
@@ -200,9 +200,9 @@ impl FromRequest for EditPostData {
 pub struct CommentData {
     post_id: u32,
     reply_to: Option<u32>,
-    nickname: CompactStr,
-    email: CompactStr,
-    content: CompactStr,
+    nickname: CompactString,
+    email: CompactString,
+    content: CompactString,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -234,7 +234,7 @@ async fn new_comment(
 async fn delete_comment(
     _: Logged,
     extract::Path(comment_id): extract::Path<u32>,
-    Query(params): Query<HashMap<CompactStr, CompactStr>>,
+    Query(params): Query<HashMap<CompactString, CompactString>>,
     Extension(db): Extension<Arc<DatabaseConnection>>,
 ) -> Result<Json<CommentRes>, HttpError> {
     if params.get("hard").is_some() {

--- a/http/src/session_store.rs
+++ b/http/src/session_store.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_session::{Session, SessionStore as AsyncSessionStore};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use tokio::fs::{File, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
@@ -22,7 +22,7 @@ pub type SessionStore = rocksdb::RocksdbStore;
 
 #[derive(Debug, Clone)]
 pub struct FileStore {
-    cache: Arc<Mutex<HashMap<CompactStr, Session>>>,
+    cache: Arc<Mutex<HashMap<CompactString, Session>>>,
     path: PathBuf,
 }
 
@@ -76,7 +76,7 @@ impl FileStore {
 
     fn regularly_check_expired(
         path: &Path,
-        cache: Arc<Mutex<HashMap<CompactStr, Session>>>,
+        cache: Arc<Mutex<HashMap<CompactString, Session>>>,
     ) {
         let path = path.to_path_buf();
         global_resource::TIME_WHEEL.add_task(Task::interval(

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 crossfire = "0.1.5"
 colored = "2"
 log = { version = "0.4", features = ["serde"] }
-compact_str = { version = "0.1", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"
 tracing = { version = "0.1", default-features = false, features = ["log", "log-always"] }
 futures = "0.3.17"

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use chrono::{DateTime, Local, NaiveDate, SecondsFormat};
 use colored::{ColoredString, Colorize};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use crossfire::mpsc;
 use crossfire::mpsc::SharedSenderBRecvF;
 use futures::FutureExt;
@@ -23,7 +23,7 @@ use global_resource::SHUTDOWN_NOTIFY;
 
 static LOGGER: Lazy<Logger> = Lazy::new(Default::default);
 
-static LOGGER_FILTER: Lazy<ArcSwap<HashMap<CompactStr, Level>>> =
+static LOGGER_FILTER: Lazy<ArcSwap<HashMap<CompactString, Level>>> =
     Lazy::new(|| {
         ArcSwap::from_pointee(
             config::get_config_temp().log().filter().clone(),
@@ -65,7 +65,7 @@ impl log::Log for Logger {
             let record = Record {
                 metadata: Metadata {
                     level: record.metadata().level(),
-                    target: CompactStr::from(
+                    target: CompactString::from(
                         record.metadata().target(),
                     ),
                 },
@@ -76,7 +76,7 @@ impl log::Log for Logger {
                         Cow::Owned(record.args().to_string())
                     }
                 },
-                file: CompactStr::from(
+                file: CompactString::from(
                     record.file().unwrap_or_default(),
                 ),
                 line: record.line().unwrap_or_default(),
@@ -162,7 +162,7 @@ struct Context {
 )]
 pub struct Metadata {
     level: Level,
-    target: CompactStr,
+    target: CompactString,
 }
 
 impl Metadata {
@@ -172,7 +172,7 @@ impl Metadata {
     }
 
     #[inline]
-    pub fn target(&self) -> &CompactStr {
+    pub fn target(&self) -> &CompactString {
         &self.target
     }
 }
@@ -181,7 +181,7 @@ impl Metadata {
 struct Record {
     metadata: Metadata,
     content: Cow<'static, str>,
-    file: CompactStr,
+    file: CompactString,
     line: u32,
     time: DateTime<Local>,
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,7 +16,7 @@ argon2 = { version = "0.3", features = ["std"] }
 rand_core = { version = "0.6", features = ["std"] }
 log = "0.4"
 once_cell = "1.8.0"
-compact_str = { version = "0.1", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 pulldown-cmark = { version = "0.8", default-features = false, features = ["simd"] }
 parse_duration = "2.1.1"
 crossfire = "0.1.7"


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning